### PR TITLE
[fix] get loadbalancer by subnet ID can not parse from the reponse

### DIFF
--- a/vcontainer/services/loadbalancer/v2/loadbalancer/iresponses.go
+++ b/vcontainer/services/loadbalancer/v2/loadbalancer/iresponses.go
@@ -19,7 +19,7 @@ type IGetResponse interface {
 // ****************************************** Response of ListBySubnetID API *******************************************
 
 type IListBySubnetIDResponse interface {
-	ToListLoadBalancerObjects() []*objects.LoadBalancer
+	ToLoadBalancerObject() *objects.LoadBalancer
 }
 
 // *********************************************** Response if List API ************************************************

--- a/vcontainer/services/loadbalancer/v2/loadbalancer/loadbalancer_test.go
+++ b/vcontainer/services/loadbalancer/v2/loadbalancer/loadbalancer_test.go
@@ -9,12 +9,20 @@ import (
 )
 
 func TestListBySubnetID(t *testing.T) {
-	clientID := ""
-	clientSecret := ""
-	projectID := "pro-xxxxxxxxx-6858-466f-bf05-df2b33faa360"
-	subnetID := "sub-xxxxxxxx-39fc-47c4-b40b-8df0ecb71045"
+	// Load file env
+	var (
+		clientID     string
+		clientSecret string
+		projectID    string
+		subnetID     string
+	)
+
+	clientID, clientSecret, projectID, subnetID = "", "", "", ""
+	// Override clientID, clientSecret, projectID, subnetID here
 
 	identityURL := "https://iamapis.vngcloud.vn/accounts-api/v2"
+	vLbURL := "https://hcm-3.api.vngcloud.vn/vserver/vlb-gateway/v2"
+
 	provider, _ := vcontainer.NewClient(identityURL)
 	vcontainer.Authenticate(provider, &oauth2.AuthOptions{
 		ClientID:     clientID,
@@ -25,7 +33,7 @@ func TestListBySubnetID(t *testing.T) {
 	})
 
 	vlb, _ := vcontainer.NewServiceClient(
-		"https://hcm-3.api.vngcloud.vn/vserver/vlb-gateway/v2",
+		vLbURL,
 		provider,
 		"vlb")
 
@@ -38,5 +46,5 @@ func TestListBySubnetID(t *testing.T) {
 		fmt.Printf("Error: %s\n", err.Error())
 	}
 
-	fmt.Printf("%v\n", resp)
+	fmt.Printf("LB: %s\n", resp[0].Name)
 }

--- a/vcontainer/services/loadbalancer/v2/loadbalancer/responses.go
+++ b/vcontainer/services/loadbalancer/v2/loadbalancer/responses.go
@@ -73,41 +73,34 @@ func (s *GetResponse) ToLoadBalancerObject() *objects.LoadBalancer {
 // ******************************************* Response of ListBySubnetID API ******************************************
 
 type ListBySubnetIDResponse struct {
-	Data []struct {
-		Address            string `json:"address"`
-		CreatedAt          string `json:"createdAt"`
-		Description        string `json:"description"`
-		DisplayStatus      string `json:"displayStatus"`
-		DisplayType        string `json:"displayType"`
-		LoadBalancerSchema string `json:"loadBalancerSchema"`
-		Name               string `json:"name"`
-		PackageId          string `json:"packageId"`
-		PrivateSubnetCidr  string `json:"privateSubnetCidr"`
-		PrivateSubnetId    string `json:"privateSubnetId"`
-		ProgressStatus     string `json:"progressStatus"`
-		Type               string `json:"type"`
-		UUID               string `json:"uuid"`
-		UpdatedAt          string `json:"updatedAt"`
-	}
+	Address            string `json:"address"`
+	CreatedAt          string `json:"createdAt"`
+	Description        string `json:"description"`
+	DisplayStatus      string `json:"displayStatus"`
+	DisplayType        string `json:"displayType"`
+	LoadBalancerSchema string `json:"loadBalancerSchema"`
+	Name               string `json:"name"`
+	PackageId          string `json:"packageId"`
+	PrivateSubnetCidr  string `json:"privateSubnetCidr"`
+	PrivateSubnetId    string `json:"privateSubnetId"`
+	ProgressStatus     string `json:"progressStatus"`
+	Type               string `json:"type"`
+	UUID               string `json:"uuid"`
+	UpdatedAt          string `json:"updatedAt"`
 }
 
-func (s *ListBySubnetIDResponse) ToListLoadBalancerObjects() []*objects.LoadBalancer {
-	if s == nil || s.Data == nil || len(s.Data) < 1 {
+func (s *ListBySubnetIDResponse) ToLoadBalancerObject() *objects.LoadBalancer {
+	if s == nil {
 		return nil
 	}
 
-	var result []*objects.LoadBalancer
-	for _, itemLb := range s.Data {
-		result = append(result, &objects.LoadBalancer{
-			UUID:     itemLb.UUID,
-			Status:   itemLb.DisplayStatus,
-			Address:  itemLb.Address,
-			Name:     itemLb.Name,
-			SubnetID: itemLb.PrivateSubnetId,
-		})
+	return &objects.LoadBalancer{
+		UUID:     s.UUID,
+		Status:   s.DisplayStatus,
+		Address:  s.Address,
+		Name:     s.Name,
+		SubnetID: s.PrivateSubnetId,
 	}
-
-	return result
 }
 
 // *********************************************** Response of List API ************************************************

--- a/vcontainer/services/loadbalancer/v2/loadbalancer/responses_utils.go
+++ b/vcontainer/services/loadbalancer/v2/loadbalancer/responses_utils.go
@@ -8,8 +8,9 @@ func NewGetResponse() IGetResponse {
 	return &GetResponse{}
 }
 
-func NewListBySubnetIDResponse() IListBySubnetIDResponse {
-	return &ListBySubnetIDResponse{}
+func NewListBySubnetIDResponse() []*ListBySubnetIDResponse {
+	var response []*ListBySubnetIDResponse
+	return response
 }
 
 func NewListResponse() IListResponse {


### PR DESCRIPTION
- The response of the API list load balancer by subnet ID returns the response without key `data` in the response.